### PR TITLE
Fix harmful removal of node_modules folder

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,9 @@
 echo "=============> JsBase installation"
 npm test
-rm -rf ../scripts/node_modules
+
+rm -rf ../scripts/node_modules/{js-base,rx,jasmine-reporters,babel-polyfill}
 
 mkdir -p ../scripts/node_modules/js-base/ 2>> /dev/null
-# mkdir -p ../scripts/node_modules/rx 2>> /dev/null
 mkdir -p ../scripts/node_modules/rx/dist 2>> /dev/null
 
 # mkdir -p ../scripts/node_modules/jasmine-reporters 2>> /dev/null


### PR DESCRIPTION
As described in Issue #6, current installation script removes `scripts/node_modules` folder which is not desired behaviour since user can have different node_modules. 

In this pull request I fixed it so only `js-base` related folders will be removed from `scripts/node_modules`.